### PR TITLE
add CRUD for creating a new business

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -26,8 +26,30 @@ class BusinessesController < ApplicationController
     end
   end
 
+  def new
+    @business = Business.new
+  end
+
+  def create
+    user = current_user
+    @business = Business.new(new_business_params)
+    user.businesses << @business
+
+    if @business.save
+      flash[:success] = "Business successfully created!"
+      redirect_to dashboard_path
+    else
+      flash.now[:error] = @business.errors.full_messages
+      render :new
+    end
+  end
+
 private
   def business_params
     params.require(:business).permit(:name, :description, :slug)
+  end
+
+  def new_business_params
+    params.require(:business).permit(:name, :description)
   end
 end

--- a/app/services/permissions_service.rb
+++ b/app/services/permissions_service.rb
@@ -20,6 +20,7 @@ class PermissionsService
     if user
       return true if controller == "bids" && action.in?(%w(index create))
       return true if controller == "users" && action.in?(%w(show edit update))
+      return true if controller == "businesses" && action.in?(%w(new create))
 
       if user.platform_admin?
 

--- a/app/views/business/dashboard/show.html.erb
+++ b/app/views/business/dashboard/show.html.erb
@@ -3,11 +3,15 @@
 </div>
 
 <div class="business_items">
-  <% if @business.items.exists? %>
-    <%= render partial: 'open_auctions_table' %>
-    <%= render partial: 'closed_auctions_table' %>
-  <% else  %>
-    <p>There are no items for this business yet.</p>
-  <% end  %>
+  <% if @business.active? %>
 
+    <% if @business.items.exists? %>
+      <%= render partial: 'open_auctions_table' %>
+      <%= render partial: 'closed_auctions_table' %>
+    <% else  %>
+      <p>There are no items for this business yet.</p>
+    <% end  %>
+  <% else %>
+    <p id="pending_notice">This business is pending approval.</p>
+  <% end %>
 </div>

--- a/app/views/businesses/new.html.erb
+++ b/app/views/businesses/new.html.erb
@@ -1,0 +1,11 @@
+<div class="well well-sm">
+  <%= form_for(@business) do |f| %>
+    <%= f.label :name, "Business Name" %>
+    <%= f.text_field :name, placeholder: "Enter Business Name", class: "form-control" %>
+
+    <%= f.label :description, "Description" %>
+    <%= f.text_field :description, placeholder: "Enter Business Description", class: "form-control" %>
+
+    <%= f.submit "Create Business", class: "btn btn-default btn-block" %>
+  <% end %>
+</div>

--- a/app/views/businesses/show.html.erb
+++ b/app/views/businesses/show.html.erb
@@ -4,6 +4,10 @@
   <%= @business.description %>
 </div>
 
-<% if @business.items.exists? %>
-  <%= render "shared/item_list" %>
+<% if @business.active? %>
+  <% if @business.items.exists? %>
+    <%= render "shared/item_list" %>
+  <% end  %>
+  <% else %>
+  <p id="pending_notice" >This business is pending approval.</p>
 <% end  %>

--- a/app/views/shared/_dashboard.html.erb
+++ b/app/views/shared/_dashboard.html.erb
@@ -1,5 +1,6 @@
 <h2> Welcome, <%= @user.name %></h2>
 <%= link_to "Update Personal Account Information", user_edit_path(id: @user.id) %>
+<%= link_to "Create New Business", new_business_path %>
 
 <% if @user.items.any? %>
   <%= render partial: 'auction_buttons' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,15 +6,13 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
-
   # Basic resources
   #resources :items, only: [:index, :show]
   resources :users, only: [:new, :index, :create]
   get "/user/edit", to: "users#edit"
   patch "/user/edit", to: "users#update"
 
-
-  resources :businesses, only: [:index]
+  resources :businesses, only: [:index, :new, :create]
 
   # get '/admin-dashboard', to: 'business_admins#show', as: 'admin_dashboard'
 

--- a/spec/integration/business_dashboard_shows_item_info_spec.rb
+++ b/spec/integration/business_dashboard_shows_item_info_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature "business dashboard shows item info" do
   scenario "for a business with no items" do
     admin = create(:user)
-    business = create(:business)
+    business = create(:business, active: true)
     admin.businesses << business
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
@@ -16,7 +16,7 @@ RSpec.feature "business dashboard shows item info" do
 
   scenario "for a business with open auctions" do
     admin = create(:user)
-    business = create(:business)
+    business = create(:business, active: true)
     admin.businesses << business
     items = business.items << create_list(:item, 2)
     extra_item = create(:item)
@@ -42,14 +42,14 @@ RSpec.feature "business dashboard shows item info" do
 
   scenario "for a business with open and closed auctions" do
     admin = create(:user)
-    admin.businesses << create(:business)
+    admin.businesses << create(:business, active: true)
     business = admin.businesses.first
     business.items << create(:item)
     business.items << create(:item, status: "closed")
     open_item = business.items.first
     closed_item = business.items.last
 
-    other_business = create(:business)
+    other_business = create(:business, active: true)
     other_business.items << create(:item, status: "closed")
     other_item = other_business.items.first
 

--- a/spec/integration/user_can_create_a_new_business_spec.rb
+++ b/spec/integration/user_can_create_a_new_business_spec.rb
@@ -22,5 +22,15 @@ RSpec.feature "Business can be created" do
     expect(new_business.admins.include?(user)).to be true
 
     visit business_path(new_business.slug)
+
+    within("#pending_notice") do
+      expect(page).to have_content("This business is pending approval.")
+    end
+
+    visit business_dashboard_path(new_business.slug)
+
+    within("#pending_notice") do
+      expect(page).to have_content("This business is pending approval.")
+    end
   end
 end

--- a/spec/integration/user_can_create_a_new_business_spec.rb
+++ b/spec/integration/user_can_create_a_new_business_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Business can be created" do
+  scenario "by a registered user" do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(user)
+
+    visit dashboard_path
+
+    expect(page).to have_link("Create New Business")
+    click_link "Create New Business"
+
+    fill_in "business[name]", with: "Cubby Stuffers"
+    fill_in "business[description]",
+             with: "A vertically integrated subscription snack service"
+
+    click_button "Create Business"
+
+    new_business = Business.last
+
+    expect(new_business.admins.include?(user)).to be true
+
+    visit business_path(new_business.slug)
+  end
+end

--- a/spec/models/business_spec.rb
+++ b/spec/models/business_spec.rb
@@ -1,28 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe Business, type: :model do
-  context "relationships" do
-    it { should have_many(:items) }
-    it { should belong_to(:owner) }
+
+  let(:inactive_business) { build(:business) }
+  let(:active_business) { build(:business, active: true) }
+  let(:persistant_business) { create(:business, active: true, name: "My Fantastic #%&* business") }
+  let(:business_with_items) { create(:business_with_items) }
+  let(:business_with_items) { create(:business_with_items) }
+
+  describe "attributes" do
+    it { expect(inactive_business).to respond_to(:name) }
+    it { expect(inactive_business).to respond_to(:active) }
+    it { expect(inactive_business).to respond_to(:description) }
+    it { expect(inactive_business).to respond_to(:slug) }
+    it { expect(inactive_business).to respond_to(:owner) }
+    it { expect(inactive_business).to respond_to(:business_admins) }
+    it { expect(inactive_business).to respond_to(:admins) }
+    it { expect(inactive_business).to respond_to(:items) }
+    it { expect(active_business).to respond_to(:items) }
   end
 
-  scenario "it creates the slug" do
-    business = create(:business, name: "My Fantastic! @$#%*! Business!")
-
-    assert_equal "my-fantastic-business", business.slug
+  describe "associations" do
+    it { expect(inactive_business).to have_many(:business_admins) }
+    it { expect(inactive_business).to have_many(:admins) }
+    it { expect(inactive_business).to have_many(:items) }
+    it { expect(inactive_business).to belong_to(:owner) }
   end
 
-  scenario "it knows its open items" do
-    business = create(:business)
-    business.items << create_list(:item, 3)
+  it "generates the slug before creation" do
+    expect(inactive_business.slug).to be_nil
+    expect(persistant_business.slug).to_not be_nil
+    expect(persistant_business.slug).to eq("my-fantastic-business")
+   end
 
-    expect(business.open_items.count).to eq 3
+  it "knows its open items" do
+   expect(business_with_items.open_items.count).to eq 3
   end
 
-  scenario "it knows its closed items" do
-    business = create(:business)
-    business.items << create(:item, status: "closed")
+  it "knows its closed items" do
+    item = business_with_items.items.first
+    item.update(status: 1)
+    expect(business_with_items.closed_items.count).to eq 1
+  end
 
-    expect(business.closed_items.count).to eq 1
+  it "can create an active business" do
+    expect(active_business.active?).to be true
   end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -70,12 +70,19 @@ FactoryGirl.define do
     "User #{n}"
   end
 
-
-
   factory :business do
     sequence(:name) { |n| "Business Name #{n}"}
     active false
     description "So lit"
-  end
 
+    factory :business_with_items do
+      transient do
+        item_count 3
+      end
+
+      after(:create) do |business, evaluator|
+        create_list(:item, evaluator.item_count, business: business)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Okay so I added the ability to create a new business. Some items to consider:

We need to handle how the app handles new _but pending_ businesses. Right now, you can create an inactive business and still navigate to that business' show page. Not sure if we want that behavior. I'll create an issue for this so we don't forget.

closes #5 

connects to #120 
