### PR TITLE
148 tweak links to dashboards

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,10 @@ class User < ActiveRecord::Base
     self.platform_admin
   end
 
+  def business_admin?
+    self.businesses.exists?
+  end
+
   def admin?
     self.businesses.exists? || self.platform_admin?
   end

--- a/app/views/platform_admin/dashboard/show.html.erb
+++ b/app/views/platform_admin/dashboard/show.html.erb
@@ -1,25 +1,31 @@
 <h1>Platform Admin Dashboard</h1>
 
-<h3>Active Businesses</h3>
-<ul>
-  <% @active_businesses.each do |business| %>
-        <li id=<%= business.slug %> >
+<div id="active_businesses">
+  <h3 >Active Businesses</h3>
+  <ul>
+    <% @active_businesses.each do |business| %>
+          <li id="<%= business.slug %>" >
+            <h3><%= link_to business.name, business_dashboard_path(business.slug)%></h3>
+            <h4><%= link_to business.description, business_dashboard_path(business.slug) %></h4>
+            Status: <%= business.status %>
+            <%= link_to "Deactivate", platform_admin_deactivate_path(slug: business.slug), class: "deactivate" %>
+          </li>
+    <% end %>
+  </ul>
+</div>
+
+<hr />
+
+<div id="inactive_businesses">
+<h3 >Inactive Businesses</h3>
+  <ul>
+    <% @inactive_businesses.each do |business| %>
+        <li id="<%= business.slug %>" >
           <h3><%= link_to business.name, business_dashboard_path(business.slug)%></h3>
           <h4><%= link_to business.description, business_dashboard_path(business.slug) %></h4>
-          Status: <%= business.status %>
-          <%= link_to "Deactivate", platform_admin_deactivate_path(slug: business.slug), class: "deactivate" %>
-        </li>
-  <% end %>
-</ul>
-<hr />
-<h3>Inactive Businesses</h3>
-<ul>
-  <% @inactive_businesses.each do |business| %>
-      <li id=<%= business.slug %> >
-        <h3><%= link_to business.name, business_dashboard_path(business.slug)%></h3>
-        <h4><%= link_to business.description, business_dashboard_path(business.slug) %></h4>
-          Status: <%= business.status %>
-          <%= link_to "Activate", platform_admin_activate_path(slug: business.slug), class:"activate"%>
-       </li>
-  <% end %>
-</ul>
+            Status: <%= business.status %>
+            <%= link_to "Activate", platform_admin_activate_path(slug: business.slug), class:"activate"%>
+         </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/shared/_dashboard.html.erb
+++ b/app/views/shared/_dashboard.html.erb
@@ -1,7 +1,8 @@
-<h2> Welcome, <%= @user.name %></h2>
-<%= link_to "Update Personal Account Information", user_edit_path(id: @user.id) %><br>
-<%= link_to "Create New Business", new_business_path %><br>
-
+<div id="user-dashboard">
+  <h2> Welcome, <%= @user.name %></h2>
+  <%= link_to "Update Personal Account Information", user_edit_path(id: @user.id) %><br>
+  <%= link_to "Create A New Business", new_business_path %><br>
+</div>
 
 <% if @user.items.any? %>
   <%= render partial: 'auction_buttons' %>

--- a/app/views/shared/_main_nav.html.erb
+++ b/app/views/shared/_main_nav.html.erb
@@ -14,10 +14,9 @@
         <% if platform_admin? %>
           <li><%= link_to "Admin Dashboard", platform_admin_dashboard_path %></li>
         <% end %>
-        <% if current_user. %>
-          <li><%= link_to "Business Admin Dashboard", business_admin_dashboard_path %></li>
+        <% if current_user.business_admin?%>
+          <li><%= link_to "Admin Dashboard", business_admin_dashboard_path %></li>
         <% end %>
-        <li><%= link_to "Account Dashboard", dashboard_path %></li>
         <li><%= link_to "Logged in as #{current_user.username}.", dashboard_path %></li>
         <li><%= link_to "Log Out", logout_path, method: :delete %></li>
       <% else %>

--- a/app/views/shared/_main_nav.html.erb
+++ b/app/views/shared/_main_nav.html.erb
@@ -12,9 +12,9 @@
         <li><%= link_to "Business Index", businesses_path %></li>
       <% if current_user %>
         <% if platform_admin? %>
-          <li><%= link_to "Platform Admin Dashboard", platform_admin_dashboard_path %></li>
+          <li><%= link_to "Admin Dashboard", platform_admin_dashboard_path %></li>
         <% end %>
-        <% if current_admin? %>
+        <% if current_user. %>
           <li><%= link_to "Business Admin Dashboard", business_admin_dashboard_path %></li>
         <% end %>
         <li><%= link_to "Account Dashboard", dashboard_path %></li>

--- a/spec/integration/dashboard_access_spec.rb
+++ b/spec/integration/dashboard_access_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.feature "dashboard access" do
+
+  scenario "as a default user" do
+    user = create(:user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit root_path
+
+    within("#main-nav") do
+      expect(page).to have_link("Logged in as #{user.username}")
+      expect(page).not_to have_link("Admin Dashboard")
+    end
+
+    click_link "Logged in as #{user.username}"
+
+    within("#user-dashboard") do
+      expect(page).to have_content("Welcome, #{user.name}")
+      expect(page).to have_link("Update Personal Account Information")
+      expect(page).to have_link("Create A New Business")
+    end
+  end
+
+  scenario "as a business admin" do
+    admin = create(:user)
+    business = create(:business)
+    other_business = create(:business)
+    admin.businesses << business
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit root_path
+
+    within("#main-nav") do
+      expect(page).to have_link("Logged in as #{admin.username}")
+      expect(page).to have_link("Admin Dashboard")
+    end
+    save_and_open_page
+
+    click_link "Admin Dashboard"
+
+    save_and_open_page
+
+    within(".business_list")
+    expect(page).to have_content(business.name)
+    expect(page).not_to have_content(other_business.name)
+  end
+end

--- a/spec/integration/dashboard_access_spec.rb
+++ b/spec/integration/dashboard_access_spec.rb
@@ -37,14 +37,38 @@ RSpec.feature "dashboard access" do
       expect(page).to have_link("Logged in as #{admin.username}")
       expect(page).to have_link("Admin Dashboard")
     end
-    save_and_open_page
 
     click_link "Admin Dashboard"
 
-    save_and_open_page
+    within(".business_list") do
+      expect(page).to have_content(business.name)
+      expect(page).not_to have_content(other_business.name)
+    end
+  end
 
-    within(".business_list")
-    expect(page).to have_content(business.name)
-    expect(page).not_to have_content(other_business.name)
+  scenario "as a platform admin" do
+    admin = create(:user, platform_admin: true)
+    business1 = create(:business)
+    business2 = create(:business)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit root_path
+
+    within("#main-nav") do
+      expect(page).to have_link("Logged in as #{admin.username}")
+      expect(page).to have_link("Admin Dashboard")
+    end
+
+    click_link "Admin Dashboard"
+    expect(current_path).to eq platform_admin_dashboard_path
+
+    within("##{business1.slug}") do
+      expect(page).to have_content(business1.name)
+    end
+
+    within("##{business2.slug}") do
+      expect(page).to have_content(business2.name)
+    end
   end
 end

--- a/spec/integration/user_can_create_a_new_business_spec.rb
+++ b/spec/integration/user_can_create_a_new_business_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "Business can be created" do
 
     visit dashboard_path
 
-    expect(page).to have_link("Create New Business")
-    click_link "Create New Business"
+    expect(page).to have_link("Create A New Business")
+    click_link "Create A New Business"
 
     fill_in "business[name]", with: "Cubby Stuffers"
     fill_in "business[description]",

--- a/spec/integration/user_can_update_their_account_spec.rb
+++ b/spec/integration/user_can_update_their_account_spec.rb
@@ -24,9 +24,4 @@ RSpec.feature "User can update account" do
     expect(page).to have_content(new_user_name)
     expect(page).not_to have_content(user.username)
   end
-
-  # TODO: Any admin type (platform/owner/business admin
-  # must go to this dashboard to edit their personal information
-
-  # TODO: Add sad path test (user cannot edit another user, platform admins can?)
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,16 +111,27 @@ RSpec.describe User, type: :model do
     expect(user.open_items.count).to eq(1)
   end
 
-  it "can tell if it is a business_admin" do
+  it "can tell if it is a business_admin or a platform admin" do
     user = create(:user)
     user.businesses << create(:business, active: true)
 
     expect(user.admin?).to eq(true)
+
+    user2 = create(:user, platform_admin: true)
+    expect(user2.admin?).to eq true
+
+    user3 = create(:user)
+    expect(user3.admin?).to eq false
   end
 
-  it "can tell if it is not a business_admin" do
+  it "can tell if it is a business_admin" do
     user = create(:user)
+    user.businesses << create(:business, active: true)
 
-    expect(user.admin?).to eq(false)
+    expect(user.business_admin?).to eq(true)
+
+    user2 = create(:user)
+    expect(user2.business_admin?).to eq(false)
+
   end
 end


### PR DESCRIPTION
Closes #148 

Changes logic in view so that if a user is only a default user, they just see a link to their personal dashboard
-if they are a business admin, they see an additional link to their admin dashboard
-if they are the platform admin, they see the link to the admin dashboard, and they see the platform admin dashboard from that link
