### PR TITLE
Minor formatting edit

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,6 +27,7 @@
         <div class="smalltext">Seconds</div>
       </div>
     </div>
+    <br /><br />
 
     <% if @item.open?  %>
       <% if @item.high_bid == 0.00 %>


### PR DESCRIPTION
The first line of bid data starts under the clock, instead of one line to the side and the rest underneath
